### PR TITLE
feat: add reusable ReportsTable component and integrate into Reports screen

### DIFF
--- a/app/(users)/user/reports/page.tsx
+++ b/app/(users)/user/reports/page.tsx
@@ -1,10 +1,71 @@
+"use client";
+
+import { Report, ReportsTable } from "@/components/table/ReportsTable";
+import React from "react";
+import { Button } from "@/components/ui/button";
+
 export default function ReportsPage() {
+  const recentReports: Report[] = [
+    {
+      id: "1",
+      iconType: "calendar",
+      title: "May-June",
+      dateRange: "30/05/2025 - 30/05/2025",
+      total: "Rs.1,995.00",
+      expenseCount: 2,
+      toBeReimbursed: "Rs.1,995.00",
+      status: {
+        label: "AWAITING APPROVAL",
+        color: "orange",
+        additionalInfo: "From 27/06/2025",
+      },
+    },
+    {
+      id: "2",
+      iconType: "file-text",
+      title: "Bhive Passes and Trial Interview expense",
+      dateRange: "16/05/2025 - 16/05/2025",
+      total: "Rs.3,486.00",
+      expenseCount: 5,
+      toBeReimbursed: "Rs.0.00",
+      status: {
+        label: "REIMBURSED",
+        color: "green",
+      },
+    },
+  ];
+
+  const [selectedReports, setSelectedReports] = React.useState<Report[]>([]);
+
+  const handleSelectedRowsChange = (reports: Report[]) => {
+    setSelectedReports(reports);
+  };
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-6">Reports</h1>
-      <div className="bg-white rounded-lg shadow p-6">
-        <p className="text-slate-600">This is the Reports page where you can view and manage your expense reports.</p>
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Reports</h1>
+        <Button variant="outline">New Report</Button>
       </div>
+      
+      <ReportsTable
+        data={recentReports}
+        enableRowSelection={true}
+        onSelectedRowsChange={handleSelectedRowsChange}
+        variant="page"
+        showPagination={true}
+      />
+      
+      {selectedReports.length > 0 && (
+        <div className="flex justify-end mt-4">
+          <Button variant="outline" size="sm" className="mr-2">
+            Export {selectedReports.length} selected
+          </Button>
+          <Button size="sm">
+            Process {selectedReports.length} selected
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/table/DataTable.tsx
+++ b/components/table/DataTable.tsx
@@ -10,6 +10,7 @@ import {
   SortingState,
   getSortedRowModel,
   RowSelectionState,
+  VisibilityState,
 } from "@tanstack/react-table";
 
 import {
@@ -24,13 +25,15 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
-interface DataTableProps<TData, TValue> {
+export interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   showPagination?: boolean;
   pageSize?: number;
   enableRowSelection?: boolean;
   onSelectedRowsChange?: (selectedRows: TData[]) => void;
+  columnVisibility?: VisibilityState;
+  className?: string;
 }
 
 export function DataTable<TData, TValue>({
@@ -40,9 +43,12 @@ export function DataTable<TData, TValue>({
   pageSize = 10,
   enableRowSelection = false,
   onSelectedRowsChange,
+  columnVisibility = {},
+  className = "",
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+  const [visibility, setVisibility] = React.useState<VisibilityState>(columnVisibility);
 
   // Create a column for selection checkboxes if row selection is enabled
   const selectionColumn: ColumnDef<TData, any> = {
@@ -78,14 +84,17 @@ export function DataTable<TData, TValue>({
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     onRowSelectionChange: setRowSelection,
+    onColumnVisibilityChange: setVisibility,
     state: {
       sorting,
       rowSelection,
+      columnVisibility: visibility,
     },
     initialState: {
       pagination: {
         pageSize: pageSize,
       },
+      columnVisibility: columnVisibility,
     },
     enableRowSelection,
   });
@@ -111,7 +120,7 @@ export function DataTable<TData, TValue>({
   }, [table, rowSelection, onSelectedRowsChange, enableRowSelection]);
 
   return (
-    <div className="space-y-4">
+    <div className={`space-y-4 ${className}`}>
       <div className="rounded-md border">
         <Table>
           <TableHeader>
@@ -150,7 +159,7 @@ export function DataTable<TData, TValue>({
             ) : (
               <TableRow>
                 <TableCell
-                  colSpan={columns.length}
+                  colSpan={columns.length + (enableRowSelection ? 1 : 0)}
                   className="h-24 text-center"
                 >
                   No results.

--- a/components/table/ReportsTable.tsx
+++ b/components/table/ReportsTable.tsx
@@ -3,161 +3,17 @@
 import * as React from "react";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "./DataTable";
-import { Calendar, FileText, Receipt, CreditCard } from "lucide-react";
+import { Report, getReportsColumns, getReportsPageColumns } from "./TableColumnDefs";
 
-// Define the Report type
-export interface Report {
-  id: string;
-  iconType: "calendar" | "file-text" | "receipt" | "credit-card";
-  title: string;
-  dateRange: string;
-  total: string;
-  expenseCount: number;
-  toBeReimbursed: string;
-  status?: {
-    label: string;
-    color: "green" | "orange" | "blue" | "red";
-    additionalInfo?: string;
-  };
-}
-
-// Helper function to get the icon component based on the icon type
-const getIconComponent = (iconType: Report["iconType"]) => {
-  switch (iconType) {
-    case "calendar":
-      return Calendar;
-    case "file-text":
-      return FileText;
-    case "receipt":
-      return Receipt;
-    case "credit-card":
-      return CreditCard;
-    default:
-      return FileText;
-  }
-};
-
-// Custom cell renderer for the status column
-const StatusCell = ({ status }: { status?: Report["status"] }) => {
-  if (!status) return null;
-
-  const getStatusClasses = (color: string): { bg: string; text: string } => {
-    switch (color) {
-      case "green":
-        return { bg: "bg-green-100", text: "text-green-500" };
-      case "orange":
-        return { bg: "bg-orange-100", text: "text-orange-500" };
-      case "blue":
-        return { bg: "bg-blue-100", text: "text-blue-500" };
-      case "red":
-        return { bg: "bg-red-100", text: "text-red-500" };
-      default:
-        return { bg: "bg-gray-100", text: "text-gray-500" };
-    }
-  };
-
-  return (
-    <div className="flex flex-col items-end">
-      <div
-        className={`${getStatusClasses(status.color).bg} ${
-          getStatusClasses(status.color).text
-        } text-xs px-2 py-1 rounded-md whitespace-nowrap`}
-      >
-        {status.label}
-      </div>
-      {status.additionalInfo && (
-        <div className="text-xs text-muted-foreground mt-1">
-          {status.additionalInfo}
-        </div>
-      )}
-    </div>
-  );
-};
-
-// Custom cell renderer for the report details column
-const ReportDetailsCell = ({
-  iconType,
-  title,
-  dateRange,
-}: {
-  iconType: Report["iconType"];
-  title: string;
-  dateRange: string;
-}) => {
-  const Icon = getIconComponent(iconType);
-  return (
-    <div className="flex items-start gap-3">
-      <div className="mt-1">
-        <Icon className="h-5 w-5 text-muted-foreground" />
-      </div>
-      <div>
-        <div className="text-blue-500 font-medium">{title}</div>
-        <div className="text-xs text-muted-foreground">{dateRange}</div>
-      </div>
-    </div>
-  );
-};
-
-// Custom cell renderer for the total column
-const TotalCell = ({
-  total,
-  expenseCount,
-}: {
-  total: string;
-  expenseCount: number;
-}) => {
-  return (
-    <div className="text-right">
-      <div>{total}</div>
-      <div className="text-xs text-muted-foreground">
-        ({expenseCount} expense{expenseCount !== 1 ? "s" : ""})
-      </div>
-    </div>
-  );
-};
-
-// Define the columns for the reports table
-export const reportsColumns: ColumnDef<Report>[] = [
-  {
-    accessorKey: "details",
-    header: "REPORT DETAILS",
-    cell: ({ row }) => (
-      <ReportDetailsCell
-        iconType={row.original.iconType}
-        title={row.original.title}
-        dateRange={row.original.dateRange}
-      />
-    ),
-  },
-  {
-    accessorKey: "total",
-    header: () => <div className="text-right">TOTAL</div>,
-    cell: ({ row }) => (
-      <TotalCell
-        total={row.original.total}
-        expenseCount={row.original.expenseCount}
-      />
-    ),
-  },
-  {
-    accessorKey: "toBeReimbursed",
-    header: () => <div className="text-right">TO BE REIMBURSED</div>,
-    cell: ({ row }) => (
-      <div className="text-right">{row.original.toBeReimbursed}</div>
-    ),
-  },
-  {
-    accessorKey: "status",
-    header: () => <div className="text-right">STATUS</div>,
-    cell: ({ row }) => <StatusCell status={row.original.status} />,
-  },
-];
+export type { Report } from "./TableColumnDefs";
 
 interface ReportsTableProps {
   data: Report[];
   showPagination?: boolean;
   enableRowSelection?: boolean;
   onSelectedRowsChange?: (selectedRows: Report[]) => void;
+  variant?: "dashboard" | "page";
+  className?: string;
 }
 
 export function ReportsTable({
@@ -165,6 +21,8 @@ export function ReportsTable({
   showPagination = false,
   enableRowSelection = false,
   onSelectedRowsChange,
+  variant = "dashboard",
+  className = "",
 }: ReportsTableProps) {
   const handleSelectedRowsChange = React.useCallback(
     (selectedRows: Report[]) => {
@@ -175,13 +33,19 @@ export function ReportsTable({
     [onSelectedRowsChange]
   );
 
+  // Get the appropriate columns based on the variant
+  const columns = React.useMemo(() => {
+    return variant === "dashboard" ? getReportsColumns() : getReportsPageColumns();
+  }, [variant]);
+
   return (
     <DataTable
-      columns={reportsColumns}
+      columns={columns}
       data={data}
       showPagination={showPagination}
       enableRowSelection={enableRowSelection}
       onSelectedRowsChange={handleSelectedRowsChange}
+      className={className}
     />
   );
 }

--- a/components/table/TableColumnDefs.tsx
+++ b/components/table/TableColumnDefs.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import * as React from "react";
+import { ColumnDef } from "@tanstack/react-table";
+import { Calendar, FileText, Receipt, CreditCard } from "lucide-react";
+
+// Define the Report type
+export interface Report {
+  id: string;
+  iconType: "calendar" | "file-text" | "receipt" | "credit-card";
+  title: string;
+  dateRange: string;
+  total: string;
+  expenseCount: number;
+  toBeReimbursed: string;
+  status?: {
+    label: string;
+    color: "green" | "orange" | "blue" | "red";
+    additionalInfo?: string;
+  };
+}
+
+// Helper function to get the icon component based on the icon type
+export const getIconComponent = (iconType: Report["iconType"]) => {
+  switch (iconType) {
+    case "calendar":
+      return Calendar;
+    case "file-text":
+      return FileText;
+    case "receipt":
+      return Receipt;
+    case "credit-card":
+      return CreditCard;
+    default:
+      return FileText;
+  }
+};
+
+// Custom cell renderer for the status column
+export const StatusCell = ({ status }: { status?: Report["status"] }) => {
+  if (!status) return null;
+
+  const getStatusClasses = (color: string): { bg: string; text: string } => {
+    switch (color) {
+      case "green":
+        return { bg: "bg-green-100", text: "text-green-500" };
+      case "orange":
+        return { bg: "bg-orange-100", text: "text-orange-500" };
+      case "blue":
+        return { bg: "bg-blue-100", text: "text-blue-500" };
+      case "red":
+        return { bg: "bg-red-100", text: "text-red-500" };
+      default:
+        return { bg: "bg-gray-100", text: "text-gray-500" };
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-end">
+      <div
+        className={`${getStatusClasses(status.color).bg} ${
+          getStatusClasses(status.color).text
+        } text-xs px-2 py-1 rounded-md whitespace-nowrap`}
+      >
+        {status.label}
+      </div>
+      {status.additionalInfo && (
+        <div className="text-xs text-muted-foreground mt-1">
+          {status.additionalInfo}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Custom cell renderer for the report details column
+export const ReportDetailsCell = ({
+  iconType,
+  title,
+  dateRange,
+}: {
+  iconType: Report["iconType"];
+  title: string;
+  dateRange: string;
+}) => {
+  const Icon = getIconComponent(iconType);
+  return (
+    <div className="flex items-start gap-3">
+      <div className="mt-1">
+        <Icon className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <div>
+        <div className="text-blue-500 font-medium">{title}</div>
+        <div className="text-xs text-muted-foreground">{dateRange}</div>
+      </div>
+    </div>
+  );
+};
+
+// Custom cell renderer for the total column
+export const TotalCell = ({
+  total,
+  expenseCount,
+}: {
+  total: string;
+  expenseCount: number;
+}) => {
+  return (
+    <div className="text-right">
+      <div>{total}</div>
+      <div className="text-xs text-muted-foreground">
+        ({expenseCount} expense{expenseCount !== 1 ? "s" : ""})
+      </div>
+    </div>
+  );
+};
+
+// Define the columns for the reports table with full details
+export const getReportsColumns = (): ColumnDef<Report>[] => [
+  {
+    accessorKey: "details",
+    header: "REPORT DETAILS",
+    cell: ({ row }) => (
+      <ReportDetailsCell
+        iconType={row.original.iconType}
+        title={row.original.title}
+        dateRange={row.original.dateRange}
+      />
+    ),
+  },
+  {
+    accessorKey: "total",
+    header: () => <div className="text-right">TOTAL</div>,
+    cell: ({ row }) => (
+      <TotalCell
+        total={row.original.total}
+        expenseCount={row.original.expenseCount}
+      />
+    ),
+  },
+  {
+    accessorKey: "toBeReimbursed",
+    header: () => <div className="text-right">TO BE REIMBURSED</div>,
+    cell: ({ row }) => (
+      <div className="text-right">{row.original.toBeReimbursed}</div>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: () => <div className="text-right">STATUS</div>,
+    cell: ({ row }) => <StatusCell status={row.original.status} />,
+  },
+];
+
+// Define the columns for the reports page with additional columns
+export const getReportsPageColumns = (): ColumnDef<Report>[] => [
+  {
+    accessorKey: "id",
+    header: "ID",
+    cell: ({ row }) => <div>{row.original.id}</div>,
+  },
+  {
+    accessorKey: "details",
+    header: "NAME",
+    cell: ({ row }) => (
+      <ReportDetailsCell
+        iconType={row.original.iconType}
+        title={row.original.title}
+        dateRange={row.original.dateRange}
+      />
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: () => <div className="text-right">STATUS</div>,
+    cell: ({ row }) => <StatusCell status={row.original.status} />,
+  },
+  {
+    accessorKey: "total",
+    header: () => <div className="text-right">TOTAL</div>,
+    cell: ({ row }) => (
+      <TotalCell
+        total={row.original.total}
+        expenseCount={row.original.expenseCount}
+      />
+    ),
+  },
+  {
+    accessorKey: "toBeReimbursed",
+    header: () => <div className="text-right">TO BE REIMBURSED</div>,
+    cell: ({ row }) => (
+      <div className="text-right">{row.original.toBeReimbursed}</div>
+    ),
+  },
+];


### PR DESCRIPTION
# Reports Table

## Description

This PR adds a reusable table component and implements the reports screen using it. It includes the following updates:

- Refactored the existing Table component to support dynamic columns and data
- Created a ReportsTable component using the generic Table
- Implemented the Reports screen layout with the new ReportsTable

The table supports flexible rendering and is designed for reuse in other parts of the app.
